### PR TITLE
compatibility with GPT-4-Turbo models + a new instruction

### DIFF
--- a/browserpilot/agents/compilers/instruction_compiler.py
+++ b/browserpilot/agents/compilers/instruction_compiler.py
@@ -6,6 +6,7 @@ import io
 import logging
 import traceback
 import os
+import re
 
 from typing import Dict, List, Union
 
@@ -297,7 +298,6 @@ class InstructionCompiler:
                     frequency_penalty=0,
                     presence_penalty=0,
                     temperature=temperature,
-                    stop=stop,
                 )
                 text = response.choices[0].message.content
             else:
@@ -325,6 +325,9 @@ class InstructionCompiler:
             )
         except Exception:
             traceback.print_exc()
+
+        # Extract python code
+        text = self._extract_python_code(text)
 
         # Add to cache.
         self.api_cache[prompt] = text
@@ -405,6 +408,15 @@ class InstructionCompiler:
                 json.dump(to_dump, f, indent=4)
             elif filename.endswith(".yaml"):
                 yaml.dump(to_dump, f)
+
+    def _extract_python_code(self, input_string: str) -> str:
+        pattern = r'```python\n(.*?)```'
+        match = re.search(pattern, input_string, re.DOTALL)
+
+        if match:
+            return match.group(1)
+        else:
+            return input_string
 
 
 if __name__ == "__main__":

--- a/examples.py
+++ b/examples.py
@@ -1,7 +1,6 @@
 import click
 
 from browserpilot.agents.gpt_selenium_agent import GPTSeleniumAgent
-# from browserpilot.agents.goal_agent import GoalAgent
 
 
 # Set up multiple command CLI.
@@ -24,6 +23,7 @@ def selenium(instructions, chromedriver_path, model, memory_folder, debug, outpu
             chromedriver_path,
             instruction_output_file=output,
             model_for_instructions=model,
+            model_for_responses=model,
             memory_folder=memory_folder,
             debug=debug,
             retry=True,

--- a/prompts/examples/github_issue.yaml
+++ b/prompts/examples/github_issue.yaml
@@ -1,0 +1,18 @@
+instructions:
+- BEGIN_FUNCTION open_github_issue
+- Go to Google.com
+- Find all textareas.
+- Find the first visible textarea.
+- Click on the first visible textarea.
+- Type in "netbox github" and press enter.
+- Wait 2 seconds.
+- Find all anchor elements that link to GitHub.
+- Click on the first one.
+- Wait 2 seconds.
+- Click on the anchor element with id 'issues-tab'.
+- Wait 2 seconds.
+- Click on the closed issues to filter them.
+- Wait 2 seconds.
+- END_FUNCTION
+- RUN_FUNCTION open_github_issue
+- Wait for 10 seconds.


### PR DESCRIPTION
Since `gpt-4-turbo-preview` and `gpt-4-1106-preview` append `"```"` to the response, I removed the `stop=` parameter which was useless and added a regex to fetch the python code. I also add a new instruction as a new scenario for github.
